### PR TITLE
Fix #1686: remove "customs" from properties to clean

### DIFF
--- a/shinken/misc/regenerator.py
+++ b/shinken/misc/regenerator.py
@@ -975,7 +975,7 @@ class Regenerator(object):
         clean_prop = ['id', 'check_command', 'hostgroups',
                       'contacts', 'notification_period', 'contact_groups',
                       'check_period', 'event_handler',
-                      'maintenance_period', 'realm', 'customs', 'escalations']
+                      'maintenance_period', 'realm', 'escalations']
 
         # some are only use when a topology change happened
         toplogy_change = b.data['topology_change']


### PR DESCRIPTION
If manage_update_host_status_brok deletes "customs" from brok, WebUI does not show changes from CHANGE_CUSTOM_HOST_VAR.